### PR TITLE
no mountpoints anymore in ver 1.11

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,9 +72,6 @@ telegraf_plugins_base:
       fielddrop:
         - "time_*"
   - name: disk
-    options:
-      mountpoints:
-        - "/"
   - name: diskio
     options:
       skip_serial_number: "true"


### PR DESCRIPTION
```
2019-06-19T18:56:35Z I! Starting Telegraf 1.11.0
2019-06-19T18:56:35Z E! [telegraf] Error running agent: Error parsing /etc/telegraf/telegraf.conf, line 114: field corresponding to `mountpoints' in disk.DiskStats cannot be set through TOML
```